### PR TITLE
chore: refactored splitIntoChunks

### DIFF
--- a/backend/src/models/AIParent.ts
+++ b/backend/src/models/AIParent.ts
@@ -4,43 +4,24 @@ abstract class AIParent {
   protected abstract maxPromptLength: number;
 
   // Splits data into manageable chunks of data to feed into the AI model
-  // Each model will have a different max prompt length as seen on line 4.
-  // protected splitIntoChunks(data: string): string[] {
-  //   const chunks: string[] = [];
-  //   let startIndex = 0;
-
-  //   while (startIndex < data.length) {
-  //     chunks.push(data.slice(startIndex, startIndex + this.maxPromptLength));
-  //     startIndex += this.maxPromptLength;
-  //   }
-
-  //   return chunks;
-  // }
+  // Each model will have a different maxPromptLength.
 
   protected splitIntoChunks(data: string): string[] {
     const chunks: string[] = [];
     let startIndex = 0;
 
     while (startIndex < data.length) {
-      // Find the next chunk ending point without breaking JSON events
       let endIndex = startIndex + this.maxPromptLength;
       
-      // If the end index goes beyond the data length, set it to the data length
       if (endIndex >= data.length) {
         chunks.push(data.slice(startIndex));
         break;
       }
+      
+      const breakpoint = data.lastIndexOf('{\"type\":', endIndex);
 
-      // Move the end index backwards to a point that keeps JSON structure intact
-      const lastComma = data.lastIndexOf('},{', endIndex);
-      const lastBrace = data.lastIndexOf('}{', endIndex);
-
-      // Choose the latest natural breakpoint
-      const breakpoint = Math.max(lastComma, lastBrace);
-
-      // If a breakpoint is found within bounds, adjust endIndex to it
       if (breakpoint > startIndex) {
-        endIndex = breakpoint + 1; // Include the comma or brace in the chunk
+        endIndex = breakpoint;
       }
 
       chunks.push(data.slice(startIndex, endIndex));


### PR DESCRIPTION
Removed old commented out function.
Increased pattern specificity.
The break did not look like it worked locally because the chunk size was too small, leading endIndex to be used rather than breakpoint.